### PR TITLE
Support snake cased URL parameters for fields

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Add the sidebar widget to a model by adding a **JSON field** and setting the pre
 
 ![](docs/plugin-instance-settings.jpg)
 
-Enter the URL pattern for this model. You can add model field values using `{ fieldKey }`. The item ID and item model API key are available using `{ id }` and `{ modelApiKey }`. The current locale is available using `{ locale }` (*note: localization must be enabled on the field* to make the `locale` value available).
+Enter the URL pattern for this model. You can add model field values using `{ field_key }`. The item ID and item model API key are available using `{ id }` and `{ modelApiKey }`. The current locale is available using `{ locale }` (*note: localization must be enabled on the field* to make the `locale` value available).
 
 This results in **model-specific URLs** in the sidebar of your content page:
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ function startPlugin(plugin) {
   const { urlPattern } = plugin.parameters.instance;
   const { datoApiToken } = plugin.parameters.global;
   const isMultiLocale = (plugin.site.attributes.locales.length > 1);
-  const paramPattern = /({\s?[0-9a-zA-Z]+\s?})/g;
+  const paramPattern = /({\s?[0-9a-zA-Z_]+\s?})/g;
   const paramMatches = urlPattern.match(paramPattern) || [];
   const paramFields = paramMatches.map(param => param.substring(1, param.length - 2).trim());
 


### PR DESCRIPTION
Currently only url params with a-z and A-Z are picked up by the plugin.

E.g. the URL pattern `/{ slugName }` works but `/{ slug_name}` does not. But Dato keys the field that you name `Slug name` as `slug_name` by default. So to me it makes sense to add an underscore to the url pattern.

I've also updated the readme to hint towards the snake cased field key instead of the camel cased field key.