### PR TITLE
Change deprecated method String.substr() to String.substring()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ function startPlugin(plugin) {
       triggers.forEach((trigger) => {
         const { name: text, frontend_url: baseUrl } = trigger.attributes;
         const url = (baseUrl.endsWith('/') && urlPath.startsWith('/'))
-          ? `${baseUrl}${urlPath.substr(1)}`
+          ? `${baseUrl}${urlPath.substring(1)}`
           : `${baseUrl}${urlPath}`;
         const item = createItem({ url, text });
         list.appendChild(item);


### PR DESCRIPTION
While using a self-hosted version of this plugin with some changes, I noticed my editor was screaming at me for using the deprecated (or rather never really well-supported) `substr()` instead of `substring()`. I see it used correctly in other lines of this file, so I think considering using substring() would be a good idea.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring